### PR TITLE
Refactored to use templates and allows vectors to be read from settings into a std::vector container

### DIFF
--- a/SettingsParser/SettingsParser.cpp
+++ b/SettingsParser/SettingsParser.cpp
@@ -66,7 +66,7 @@ bool SettingsParser::read()
             // skip the assignment
             while(std::isspace(line[j], loc) || line[j] == '=')
                 j++;
-            
+
             // get the value string
             const std::string value = line.substr(j, line.size() - j);
 
@@ -117,7 +117,7 @@ bool SettingsParser::write() const
                     // skip the assignment
                     while(std::isspace(line[j], loc) || line[j] == '=')
                         j++;
-                
+
                     // get the value string
                     value = line.substr(j, line.size() - j);
                 }
@@ -159,12 +159,11 @@ bool SettingsParser::write() const
     return true;
 }
 
-
 void SettingsParser::print() const
 {
     for(auto& element: m_data)
         std::cout << element.first << " = " << element.second<< std::endl;
-
+    
     std::cout << std::endl << "Size: " << m_data.size() << std::endl;
 }
 
@@ -172,127 +171,4 @@ void SettingsParser::print() const
 bool SettingsParser::isChanged() const
 {
     return m_isChanged;
-}
-
-
-void SettingsParser::get(const std::string& key, std::string &value) const
-{
-    std::map<std::string, std::string>::const_iterator it = m_data.find(key);
-    if (it != m_data.end())
-    {
-        value = it->second;
-    }
-}
-
-
-void SettingsParser::get(const std::string& key, bool &value) const
-{
-    std::map<std::string, std::string>::const_iterator it = m_data.find(key);
-    if (it != m_data.end())
-    {
-        value = ((it->second == "TRUE") ? true : false);
-    }
-}
-
-
-void SettingsParser::get(const std::string& key, char &value) const
-{
-    std::map<std::string, std::string>::const_iterator it = m_data.find(key);
-    if (it != m_data.end())
-    {
-        value = it->second[0];
-    }
-}
-
-
-void SettingsParser::get(const std::string& key, int &value) const
-{
-    std::map<std::string, std::string>::const_iterator it = m_data.find(key);
-    if (it != m_data.end())
-    {
-        std::stringstream ss(it->second);
-        ss >> value;
-    }
-}
-
-
-void SettingsParser::get(const std::string& key, float &value) const
-{
-    std::map<std::string, std::string>::const_iterator it = m_data.find(key);
-    if (it != m_data.end())
-    {
-        std::stringstream ss(it->second);
-        ss >> value;
-    }
-}
-
-
-void SettingsParser::set(const std::string& key, const std::string value)
-{
-    std::map<std::string, std::string>::iterator it = m_data.find(key);
-    if (it != m_data.end())
-    {
-        it->second = value;
-        m_isChanged =  true;
-    }                                 
-}
-
-void SettingsParser::set(const std::string& key, const char* value)
-{
-    std::map<std::string, std::string>::iterator it = m_data.find(key);
-    if (it != m_data.end())
-    {
-        it->second = std::string(value);
-        m_isChanged =  true;
-    }                                 
-}
-
-
-void SettingsParser::set(const std::string& key, const bool value)
-{
-    std::map<std::string, std::string>::iterator it = m_data.find(key);
-    if (it != m_data.end())
-    {
-        it->second = (value) ? "TRUE" : "FALSE";
-        m_isChanged =  true;
-    }
-}
-
-
-void SettingsParser::set(const std::string& key, const char value)
-{
-    std::map<std::string, std::string>::iterator it = m_data.find(key);
-    if (it != m_data.end())
-    {
-        std::string tmp = "";
-        tmp = value;
-        it->second = tmp;
-        m_isChanged =  true;
-    }
-}
-
-
-void SettingsParser::set(const std::string& key, const int value)
-{
-    std::map<std::string, std::string>::iterator it = m_data.find(key);
-    if (it != m_data.end())
-    {
-        std::stringstream ss;
-        ss << value;
-        it->second = ss.str();
-        m_isChanged =  true;
-    }
-}
-
-
-void SettingsParser::set(const std::string& key, const float value)
-{
-    std::map<std::string, std::string>::iterator it = m_data.find(key);
-    if (it != m_data.end())
-    {
-        std::stringstream ss;
-        ss << value;
-        it->second = ss.str();
-        m_isChanged =  true;
-    }
 }

--- a/SettingsParser/SettingsParser.hpp
+++ b/SettingsParser/SettingsParser.hpp
@@ -1,8 +1,11 @@
+
 #ifndef SETTINGSPARSER_INCLUDE
 #define SETTINGSPARSER_INCLUDE
 
 #include <string>
 #include <map>
+#include <vector>
+#include <sstream>
 
 class SettingsParser 
 {
@@ -14,24 +17,28 @@ public:
     bool saveToFile();
 
     bool isChanged() const;
-
-    void get(const std::string& key, std::string &value) const;
-    void get(const std::string& key, bool &value) const;
-    void get(const std::string& key, char &value) const;
-    void get(const std::string& key, int &value) const;
-    void get(const std::string& key, float &value) const;
-
-    void set(const std::string& key, const std::string value);
-    void set(const std::string& key, const char* value);
-    void set(const std::string& key, const bool value);
-    void set(const std::string& key, const char value);
-    void set(const std::string& key, const int value);
-    void set(const std::string& key, const float value);
+    
+    template<typename T>
+    void get(const std::string& key, T & value);
+    template<typename T>
+    void get(const std::string& key, std::vector<T> &value);
+    
+    template<typename T>
+    void set(const std::string &key, const T value);
+    template<typename T>
+    void set(const std::string& key, const std::vector<T> value);
 
     void print() const;
 
-
 private:
+    
+    //return the string in the type of T
+    template<typename T>
+    T convertToType(const std::string &input);
+    //return string of type T
+    template<typename T>
+    std::string convertToStr(const T input);
+    
     bool read();
     bool write() const;
 
@@ -39,5 +46,176 @@ private:
     std::string m_filename;
     std::map<std::string, std::string> m_data;
 };
+
+
+template<typename T>
+inline std::string SettingsParser::convertToStr(T input)  {
+    throw "Unsupported type supplied, either change types, or write a correct conversion function for the template type.";
+}
+
+template<>
+inline std::string SettingsParser::convertToStr<std::string>(std::string value) {
+    return value;
+}
+
+template<>
+inline std::string SettingsParser::convertToStr<const char*>(const char* value)  {
+    return std::string(value);
+}
+
+template<>
+inline std::string SettingsParser::convertToStr<bool>(bool value)  {
+    return (value) ? "TRUE" : "FALSE";
+}
+
+template<>
+inline std::string SettingsParser::convertToStr<char>(char value)  {
+    std::string tmp = "";
+    tmp = value;
+    return tmp;
+}
+
+template<>
+inline std::string SettingsParser::convertToStr<int>(int value)  {
+    std::stringstream ss;
+    ss << value;
+    return ss.str();
+}
+
+template<>
+inline std::string SettingsParser::convertToStr<float>(float value)  {
+    std::stringstream ss;
+    ss << value;
+    return ss.str();
+}
+
+template<>
+inline std::string SettingsParser::convertToStr<short>(short value)  {
+    std::stringstream ss;
+    ss << value;
+    return ss.str();
+}
+
+template<>
+inline std::string SettingsParser::convertToStr<double>(double value)  {
+    std::stringstream ss;
+    ss << value;
+    return ss.str();
+}
+
+template <typename T>
+inline T SettingsParser::convertToType(const std::string &input)  {
+    throw "Unconvertable type encountered, please use a different type, or define the handle case in SettingsParser.hpp";
+}
+
+template<>
+inline int SettingsParser::convertToType<int>(const std::string &input) {
+    int value;
+    std::stringstream ss(input);
+    ss >> value;
+    
+    return value;
+}
+
+template<>
+inline double SettingsParser::convertToType<double>(const std::string &input)  {
+    double value;
+    std::stringstream ss(input);
+    ss >> value;
+    
+    return value;
+}
+
+template<>
+inline float SettingsParser::convertToType<float>(const std::string &input)  {
+    float value;
+    std::stringstream ss(input);
+    ss >> value;
+    
+    return value;
+}
+
+template<>
+inline short SettingsParser::convertToType<short>(const std::string &input)  {
+    short value;
+    std::stringstream ss(input);
+    ss >> value;
+    
+    return value;
+}
+
+template<>
+inline bool SettingsParser::convertToType<bool>(const std::string &input)  {
+    return input == "TRUE" ? true : false;
+}
+
+template<>
+inline char SettingsParser::convertToType<char>(const std::string &input)  {
+    return input[0];
+}
+
+template<>
+inline std::string SettingsParser::convertToType<std::string>(const std::string &input)  {
+    return input;
+}
+
+template<typename T>
+inline void SettingsParser::get(const std::string& key, T &value) {
+    std::map<std::string, std::string>::const_iterator it = m_data.find(key);
+    
+    if (it !=  m_data.end()){
+        value = convertToType<T>(it->second);
+    }
+}
+
+template<typename T>
+inline void SettingsParser::get(const std::string& key, std::vector<T> &value) {
+    std::map<std::string, std::string>::const_iterator it = m_data.find(key);
+    if (it!=m_data.end()){
+        
+        std::string output;
+        std::istringstream parser(it->second);
+        
+        int index = 0;
+        
+        //split by comma
+        while (getline(parser, output, ',')){
+            
+            if (index < value.size())
+                value.at(index) = convertToType<T>(output);
+            else
+                value.push_back(convertToType<T>(output));
+            
+            ++index;
+        }
+    }
+}
+
+template<typename T>
+inline void SettingsParser::set(const std::string& key, const T value){
+    std::map<std::string, std::string>::iterator it = m_data.find(key);
+    if (it != m_data.end())
+    {
+        it->second = convertToStr<T>(value);
+        m_isChanged =  true;
+    }
+}
+
+template<typename T>
+inline void SettingsParser::set(const std::string &key, const std::vector<T> value){
+    std::map<std::string, std::string>::iterator it = m_data.find(key);
+    
+    if (it != m_data.end()) {
+        
+        std::string setString;
+        for (int i = 0; i < value.size() - 1; ++i){
+            setString += convertToStr<T>(value.at(i)) + ",";
+        }
+        setString+=convertToStr<T>(value.back());
+        
+        it->second = setString;
+        m_isChanged = true;
+    }
+}
 
 #endif // SETTINGSPARSER_INCLUDE

--- a/SettingsParser/main.cpp
+++ b/SettingsParser/main.cpp
@@ -1,5 +1,6 @@
 #include "SettingsParser.hpp"
 #include <iostream>
+#include <vector>
 
 int main()
 {
@@ -31,6 +32,9 @@ int main()
     bool fullscreen;
     settings.get("fullscreen", fullscreen);
 
+    std::vector<int> rectangle;
+    settings.get("rectangle", rectangle);
+    
     //....
 
     std::string newTitle = "SFML Settings Parser rocks!";

--- a/SettingsParser/settings.txt
+++ b/SettingsParser/settings.txt
@@ -11,8 +11,11 @@ height = 768
 # window title
 title = sfml tutorial
 
-# phycics constants
+# physics constants
 g = 9.81
+
+# create a rectangle at 10, 10 with width 5, height 10
+rectangle = 10,10,5,10
 
 # player initials (since the key is the same the value will be overwritten)
 player = M


### PR DESCRIPTION
This pull request involves refactoring the code to use templates & specialisation, instead of overloads, which reduces code duplication, and allows easier changes to be made.

The switch to a template based system was chosen to allow reading of comma separated strings into a vector (which type is determined by the user). It also allows writing of vectors to the file.

(Now with only one commit!) :)
